### PR TITLE
chore: update references from 'course' to 'exercise' in documentation

### DIFF
--- a/.github/steps/2-commit-a-file.md
+++ b/.github/steps/2-commit-a-file.md
@@ -11,7 +11,7 @@ Creating a branch allows you to edit your project without changing the `main` br
 The following steps will guide you through the process of committing a change on GitHub. A commit records changes in renaming, changing content within, creating a new file, and any other changes made to your project. For this exercise, committing a change requires first adding a new file to your new branch.
 
 > [!NOTE]
-> `.md` is a file extension that creates a Markdown file. You can learn more about Markdown by visiting "[Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)" in our docs or by taking the "[Communicating using Markdown](https://github.com/skills/communicate-using-markdown)" Skills course.
+> `.md` is a file extension that creates a Markdown file. You can learn more about Markdown by visiting "[Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)" in our docs or by taking the "[Communicating using Markdown](https://github.com/skills/communicate-using-markdown)" Skills Exercise.
 
 1. On the **< > Code** tab in the header menu of your repository, make sure you're on your new branch `my-first-branch`.
 

--- a/.github/steps/x-review.md
+++ b/.github/steps/x-review.md
@@ -1,6 +1,6 @@
 ## Review
 
-_Congratulations, you've completed this course and joined the world of developers!_
+_Congratulations, you've completed this Exercise and joined the world of developers!_
 
 <img src=https://octodex.github.com/images/collabocats.jpg alt=celebrate width=300 align=right>
 
@@ -19,11 +19,11 @@ If you'd like to make a profile README, use the quickstart instructions below or
 2. Create a file named `README.md` in its root. The "root" means not inside any folder in your repository.
 3. Edit the contents of the `README.md` file.
 4. If you created a new branch for your file, open and merge a pull request on your branch.
-5. Lastly, we'd love to hear what you thought of this course [in our discussion board](https://github.com/orgs/skills/discussions/categories/introduction-to-github).
+5. Lastly, we'd love to hear what you thought of this exercise [in our discussion board](https://github.com/orgs/skills/discussions/categories/introduction-to-github).
 
 Check out these resources to learn more or get involved:
 
 - Are you a student? Check out the [Student Developer Pack](https://education.github.com/pack).
-- [Take another GitHub Skills course](https://github.com/skills).
+- [Take another GitHub Skills exercise](https://github.com/skills).
 - [Read the GitHub Getting Started docs](https://docs.github.com/en/get-started).
 - To find projects to contribute to, check out [GitHub Explore](https://github.com/explore).

--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -1,4 +1,4 @@
-name: Step 0 # Start Course
+name: Step 0 # Start Exercise
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Introduction to GitHub
 
-<!-- ![](../../actions/workflows/0-start-course.yml/badge.svg?branch=main) -->
-![](../../actions/workflows/1-create-a-branch.yml/badge.svg?branch=my-first-branch)
-![](../../actions/workflows/2-commit-a-file.yml/badge.svg?branch=my-first-branch)
-![](../../actions/workflows/3-open-a-pull-request.yml/badge.svg?branch=my-first-branch)
-![](../../actions/workflows/4-merge-your-pull-request.yml/badge.svg?branch=my-first-branch)
+<!-- ![](../../actions/workflows/0-start-exercise.yml/badge.svg) -->
+![](../../actions/workflows/1-create-a-branch.yml/badge.svg)
+![](../../actions/workflows/2-commit-a-file.yml/badge.svg)
+![](../../actions/workflows/3-open-a-pull-request.yml/badge.svg)
+![](../../actions/workflows/4-merge-your-pull-request.yml/badge.svg)
 
 _Get started using GitHub in less than an hour._
 

--- a/README.md
+++ b/README.md
@@ -10,27 +10,27 @@ _Get started using GitHub in less than an hour._
 
 ## Welcome
 
-People use GitHub to build some of the most advanced technologies in the world. Whether you’re visualizing data or building a new game, there’s a whole community and set of tools on GitHub that can help you do it even better. GitHub Skills’ “Introduction to GitHub” course guides you through everything you need to start contributing in less than an hour.
+People use GitHub to build some of the most advanced technologies in the world. Whether you’re visualizing data or building a new game, there’s a whole community and set of tools on GitHub that can help you do it even better. GitHub Skills’ “Introduction to GitHub” exercise guides you through everything you need to start contributing in less than an hour.
 
 - **Who is this for**: New developers, new GitHub users, and students.
 - **What you'll learn**: We'll introduce repositories, branches, commits, and pull requests.
 - **What you'll build**: We'll make a short Markdown file you can use as your [profile README](https://docs.github.com/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme).
-- **Prerequisites**: None. This course is a great introduction for your first day on GitHub.
-- **How long**: This course takes less than one hour to complete.
+- **Prerequisites**: None. This exercise is a great introduction for your first day on GitHub.
+- **How long**: This exercise takes less than one hour to complete.
 
-In this course, you will:
+In this exercise, you will:
 
 1. Create a branch
 2. Commit a file
 3. Open a pull request
 4. Merge your pull request
 
-### How to start this course
+### How to start this exercise
 
-1. Right-click **Copy Course** and open the link in a new tab.
+1. Right-click **Copy Exercise** and open the link in a new tab.
 
-   <a id="copy-course" href="https://github.com/new?template_owner=FidelusAleksander&template_name=introduction-to-github&owner=%40me&name=skills-introduction-to-github&description=My+Course:+Get+started+using+GitHub&visibility=public">
-      <img src="https://img.shields.io/badge/📠_Copy_Course-008000" height="25pt"/>
+   <a id="copy-exercise" href="https://github.com/new?template_owner=FidelusAleksander&template_name=introduction-to-github&owner=%40me&name=skills-introduction-to-github&description=Exercise:+Get+started+using+GitHub&visibility=public">
+      <img src="https://img.shields.io/badge/📠_Copy_Exercise-008000" height="25pt"/>
    </a>
 
 2. In the new tab, most of the prompts will automatically fill in for you.
@@ -38,18 +38,18 @@ In this course, you will:
    - We recommend creating a public repository, as private repositories will [use Actions minutes](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions).
    - Scroll down and click the **Create repository** button at the bottom of the form.
 
-3. After your new repository is created, wait about 20 seconds for the course to be prepared.
-   - The **Copy Course** button will deactivate, changing to gray.
-   - The **Start Lesson** button will activate, changing to green.
+3. After your new repository is created, wait about 20 seconds for the exercise to be prepared.
+   - The **Copy Exercise** button will deactivate, changing to gray.
+   - The **Start Exercise** button will activate, changing to green.
 
-4. Click **Start Lesson**. Follow the step-by-step instructions and feedback will be provided as you progress.
+4. Click **Start Exercise**. Follow the step-by-step instructions and feedback will be provided as you progress.
 
-   <a id="start_lesson">
-      <img src="https://img.shields.io/badge/🚀_Start_Lesson-AAA" height="25pt"/>
+   <a id="start-exercise">
+      <img src="https://img.shields.io/badge/🚀_Start_Exercise-AAA" height="25pt"/>
    </a>
 
 > [!IMPORTANT]
-> The **Start Lesson** button will activate after copying the course. You will probably need to refresh the page.
+> The **Start Exercise** button will activate after copying the repository. You will probably need to refresh the page.
 
 ---
 


### PR DESCRIPTION
This pull request includes changes to update terminology from "course" to "exercise" throughout the documentation and workflow files. The most important changes include updates to the README file, workflow file renaming, and modifications to step-by-step instructions.

Terminology updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R52): Changed references from "course" to "exercise" to reflect the new terminology.
* [`.github/steps/2-commit-a-file.md`](diffhunk://#diff-1fde82622489f7231c8374daa68e766a7672ed42811751f3013142e7716f3906L14-R14): Updated the note to refer to the "Skills Exercise" instead of "Skills course."
* [`.github/steps/x-review.md`](diffhunk://#diff-42f53dcd85649fb11d54c8c516d51edbd0d5ae7f35331fab0aa7f72f90a4b547L3-R3): Modified congratulatory message and feedback request to use "exercise" instead of "course." [[1]](diffhunk://#diff-42f53dcd85649fb11d54c8c516d51edbd0d5ae7f35331fab0aa7f72f90a4b547L3-R3) [[2]](diffhunk://#diff-42f53dcd85649fb11d54c8c516d51edbd0d5ae7f35331fab0aa7f72f90a4b547L22-R27)

Workflow file updates:

* [`.github/workflows/0-start-exercise.yml`](diffhunk://#diff-391af7b32d36608157476690176e9511356d1dc7b17f7e2c596e0128cf485bc0L1-R1): Renamed from `.github/workflows/0-start-course.yml` and updated the name field to "Start Exercise."